### PR TITLE
Updated loaderVersion to 44 in mods.toml

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[43,)"
+loaderVersion="[44,)"
 license="All rights reserved"
 [[mods]]
 modId="ruby"


### PR DESCRIPTION
Forge 43 is 1.19.2 and 44 is 1.19.3, 43 works, but 44 is better for consistency